### PR TITLE
fix bug causing median() to break if only one tick recorded

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ var timer = function(name) {
                 });
                 var half = Math.floor(this.ticks.length/2);
 
-                if (this.ticks.lenght % 2) {
+                if (this.ticks.length % 2) {
                     return (this.ticks[half].end - this.ticks[half].start);
                 } else {
                     return (this.ticks[half-1].end - this.ticks[half-1].start)


### PR DESCRIPTION
Small typo (`lenght` -> `length`) causes median() to error out:

```
/Users/gzheng/Dev/stress/node_modules/exectimer/index.js:18
                    return (this.ticks[half-1].end - this.ticks[half-1].start)
                                              ^
TypeError: Cannot read property 'end' of undefined
    at Object.timers.(anonymous function).median (/Users/gzheng/Dev/stress/node_modules/exectimer/index.js:18:47)
    at Object.<anonymous> (/Users/gzheng/Dev/stress/omg.js:13:34)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
    at startup (node.js:119:16)
    at node.js:906:3
```

While trying to do:

```
var t = require("exectimer");

var tick = new t.tick("myFunction");
tick.start();
// do some processing and end this tick
tick.stop();


// Display the results
console.log(t.timers.myFunction.duration()); // total duration of all ticks
console.log(t.timers.myFunction.min()); // minimal tick duration
console.log(t.timers.myFunction.max()); // maximal tick duration
console.log(t.timers.myFunction.mean()); // mean tick duration
console.log(t.timers.myFunction.median()); // median tick duration
console.log(t.timers.myFunction.start()); // timestamp of the start of the first tick
console.log(t.timers.myFunction.end()); // timestamp of the end of the last tick
```
