### PR TITLE
Includes license info in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "exectimer",
   "version": "2.2.1",
   "description": "Very simple module to calculate block execution time.",
+  "license": "MIT",
   "keywords": [
     "time",
     "timer",


### PR DESCRIPTION
Automated tooling that checks license terms for compliance can require the use of a `license` key in `package.json`; this PR adds it in alignment with the existing license.